### PR TITLE
Update to Diffbot API v3

### DIFF
--- a/lib/diffbot.js
+++ b/lib/diffbot.js
@@ -42,7 +42,7 @@ Diffbot.prototype.article = function (options, callback) {
     throw new Error("the URI is required.");
   }
 
-  var diffbot_url = "http://www.diffbot.com/api/article?token=" + this.token + "&url=" + encodeURIComponent(options.uri);
+  var diffbot_url = "http://api.diffbot.com/v3/article?token=" + this.token + "&url=" + encodeURIComponent(options.uri);
 
   // process extras
   if (options.callback) {
@@ -96,7 +96,7 @@ Diffbot.prototype.frontpage = function (options, callback) {
     throw new Error("the URI is required.");
   }
 
-  var diffbot_url = "http://www.diffbot.com/api/frontpage?token=" + this.token + "&url=" + encodeURIComponent(options.uri) + "&format=json";
+  var diffbot_url = "http://api.diffbot.com/v3/frontpage?token=" + this.token + "&url=" + encodeURIComponent(options.uri) + "&format=json";
 
   request({uri: diffbot_url}, function(error, response, body) {
     if (error) {


### PR DESCRIPTION
They've recently changed their URLs: http://support.diffbot.com/automatic-apis/moving-to-new-versions-of-diffbot-apis/
