### PR TITLE
Fixed crashes and added a new option for simpler extraction

### DIFF
--- a/lib/diffbot.js
+++ b/lib/diffbot.js
@@ -79,7 +79,7 @@ Diffbot.prototype.article = function (options, callback) {
       } catch (e) {
         return callback(e, undefined);
       }
-      callback(false, parsedJSON);
+      return callback(false, parsedJSON);
     }
   });
 }
@@ -112,7 +112,7 @@ Diffbot.prototype.frontpage = function (options, callback) {
       } catch (e) {
         return callback(e, undefined);
       }
-      callback(false, parsedJSON);
+      return callback(false, parsedJSON);
     }
   });
 }

--- a/lib/diffbot.js
+++ b/lib/diffbot.js
@@ -76,6 +76,11 @@ Diffbot.prototype.article = function (options, callback) {
     } else {
       try {
         var parsedJSON = JSON.parse(body);
+        if (options.singlePage) {
+            if (parsedJSON.objects !== undefined && parsedJSON.objects[0] !== undefined) {
+                parsedJSON = parsedJSON.objects[0];
+            }
+        }
       } catch (e) {
         return callback(e, undefined);
       }

--- a/lib/diffbot.js
+++ b/lib/diffbot.js
@@ -72,9 +72,14 @@ Diffbot.prototype.article = function (options, callback) {
 
   request({uri: diffbot_url}, function(error, response, body) {
     if (error) {
-      callback(error, undefined);
+      return callback(error, undefined);
     } else {
-      callback(false, JSON.parse(body));
+      try {
+        var parsedJSON = JSON.parse(body);
+      } catch (e) {
+        return callback(e, undefined);
+      }
+      callback(false, parsedJSON);
     }
   });
 }
@@ -100,9 +105,14 @@ Diffbot.prototype.frontpage = function (options, callback) {
 
   request({uri: diffbot_url}, function(error, response, body) {
     if (error) {
-      callback(error, undefined);
+      return callback(error, undefined);
     } else {
-      callback(false, JSON.parse(body));
+      try {
+        var parsedJSON = JSON.parse(body);
+      } catch (e) {
+        return callback(e, undefined);
+      }
+      callback(false, parsedJSON);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "diffbot",
   "description" : "Node.js wrapper for the Diffbot Article and Frontpage APIs",
   "tags" : ["diffbot", "wrapper", "api", "article"],
-  "version" : "1.0.1",
+  "version" : "1.0.2",
   "author" : "Mark Bao <mark@markbao.com>",
   "repository" : {
     "type" : "git",


### PR DESCRIPTION
Fixed crashes due to JSON.parse().
Also added a new option flag (options.singlePage) which allows the library to parse the first object in the response, so that the library works as intended and you can directly access the title, text and other properties.
